### PR TITLE
Removed PHP 5.2 from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 5.2
   - 5.3
   - 5.4
   - 5.5


### PR DESCRIPTION
- version was removed from Travis CI some time ago