### PR TITLE
Error handling bug

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Cash Payment Solutions GmbH
+Copyright (c) 2016-2017 Cash Payment Solutions GmbH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,11 @@
-# Barzahlen Payment Module PHP SDK (v2.0.2)
+# Barzahlen Payment Module PHP SDK (v2.0.3)
 
 [![Build Status](https://travis-ci.org/Barzahlen/Barzahlen-PHP.svg?branch=master)](https://travis-ci.org/Barzahlen/Barzahlen-PHP)
 [![Total Downloads](https://poser.pugx.org/barzahlen/barzahlen-php/downloads)](https://packagist.org/packages/barzahlen/barzahlen-php)
 [![License](https://poser.pugx.org/barzahlen/barzahlen-php/license)](https://packagist.org/packages/barzahlen/barzahlen-php)
 
 ## Copyright
-(c) 2016, Cash Payment Solutions GmbH  
+(c) 2017, Cash Payment Solutions GmbH  
 https://www.barzahlen.de
 
 ## Preparation

--- a/src/Client.php
+++ b/src/Client.php
@@ -78,12 +78,13 @@ class Client
         curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, true);
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
 
+        $response = curl_exec($curl);
+        
         $error = curl_error($curl);
-        if ($error) {
+        if ($error || false === $response) {
             throw new Exception\CurlException('Error during cURL: ' . $error . ' [' . curl_errno($curl) . ']');
         }
 
-        $response = curl_exec($curl);
         $this->checkResponse($response);
         curl_close($curl);
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -26,7 +26,7 @@ class Client
     /**
      * @var string
      */
-    private $userAgent = 'PHP SDK v2.0.2';
+    private $userAgent = 'PHP SDK v2.0.3';
 
 
     /**
@@ -79,7 +79,7 @@ class Client
         curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, 2);
 
         $response = curl_exec($curl);
-        
+
         $error = curl_error($curl);
         if ($error || false === $response) {
             throw new Exception\CurlException('Error during cURL: ' . $error . ' [' . curl_errno($curl) . ']');

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -13,6 +13,10 @@ class ClientTest extends \PHPUnit_Framework_TestCase
      */
     private $client;
 
+    /**
+     * @var string
+     */
+    private $userAgent = 'PHP SDK v2.0.3';
 
     public function setUp()
     {
@@ -21,7 +25,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultUserAgent()
     {
-        $this->assertAttributeEquals('PHP SDK v2.0.2', 'userAgent', $this->client);
+        $this->assertAttributeEquals($this->userAgent, 'userAgent', $this->client);
     }
 
     public function testSetUserAgent()
@@ -41,7 +45,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $header = $this->client->buildHeader($request);
         $this->assertEquals('Host: api.barzahlen.de', $header[0]);
         $this->assertContains('Date: ', $header[1]);
-        $this->assertEquals('User-Agent: PHP SDK v2.0.2', $header[2]);
+        $this->assertEquals('User-Agent: '.$this->userAgent, $header[2]);
         $this->assertRegExp('/^Authorization: BZ1-HMAC-SHA256 DivisionId=12345, Signature=[a-f0-9]{64}$/', $header[3]);
         $this->assertRegExp('/^Idempotency-Key: [a-f0-9]{32}$/', $header[4]);
     }
@@ -54,7 +58,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
         $header = $client->buildHeader($request);
         $this->assertEquals('Host: api-sandbox.barzahlen.de', $header[0]);
         $this->assertContains('Date: ', $header[1]);
-        $this->assertEquals('User-Agent: PHP SDK v2.0.2', $header[2]);
+        $this->assertEquals('User-Agent: '.$this->userAgent, $header[2]);
         $this->assertRegExp('/^Authorization: BZ1-HMAC-SHA256 DivisionId=12345, Signature=[a-f0-9]{64}$/', $header[3]);
         $this->assertArrayNotHasKey(4, $header);
     }


### PR DESCRIPTION
The curl_exec must be called before checking for errors.
Otherwise the "handle" method just returns "false" instead of an exception in some cases.
