### PR TITLE
support for HTTP_X_FORWARDED_PORT vs SERVER_PORT + REQUEST_URI with params

### DIFF
--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -25,10 +25,16 @@ class Webhook
      */
     public function verify($header, $body)
     {
+        if (isset($header['HTTP_X_FORWARDED_HOST'])) {
+            $host = $header['HTTP_X_FORWARDED_HOST'] . ':' . $header['HTTP_X_FORWARDED_PORT'];
+        } else {
+            $host = $header['HTTP_HOST'] . ':' . $header['SERVER_PORT'];
+        }
+
         $signature = Middleware::generateSignature(
-            $header['HTTP_HOST'] . ':' . $header['SERVER_PORT'],
+            $host,
             $header['REQUEST_METHOD'],
-            $header['REQUEST_URI'],
+            strtok($header['REQUEST_URI'], '?'),
             $header['QUERY_STRING'],
             $header['HTTP_DATE'],
             '',


### PR DESCRIPTION
fixes problems with

- `HTTP_X_FORWARDED_PORT` vs `SERVER_PORT`
- `REQUEST_URI` **with** query params

`Webhook->verify()` was not generating the right signature when
- the webhook receiving script is running behind a proxy (nginx / traefik / docker) -- `SERVER_PORT` would be eg `8080` vs the expected `443` contained in `HTTP_X_FORWARDED_PORT`
- the webhook URL contains a query param -- eg `https://backend.example.com/api/v1/webhook.php?secret=foobar` -- removing all data after `?` in `REQUEST_URI` works (`QUERY_STRING` is an individual part of the signature)

after those changes it started working -- without there was no correct signature
