### PR TITLE
Check if headers for Webhook::verify() are set

### DIFF
--- a/src/Webhook.php
+++ b/src/Webhook.php
@@ -25,6 +25,10 @@ class Webhook
      */
     public function verify($header, $body)
     {
+        if(!isset($header['REQUEST_METHOD'], $header['REQUEST_URI'], $header['QUERY_STRING'], $header['HTTP_DATE'], $header['HTTP_BZ_SIGNATURE'])) {
+            return false;
+        }
+        
         if (isset($header['HTTP_X_FORWARDED_HOST'])) {
             $host = $header['HTTP_X_FORWARDED_HOST'] . ':' . $header['HTTP_X_FORWARDED_PORT'];
         } else {


### PR DESCRIPTION
Our barzahlen webhook endpoint throws many `PHP Notice Undefined index: HTTP_DATE `, `PHP Notice Undefined index: HTTP_BZ_SIGNATURE` notices.

Before verifying the webhook you should check if the necessary headers exist. If they do not exist, the verification failed.